### PR TITLE
Table breaks when urls are too long. Add CSS to allow to break them

### DIFF
--- a/golynx/static/css/styles.css
+++ b/golynx/static/css/styles.css
@@ -66,3 +66,6 @@ form input[type="submit"]:hover {
 .delete-button:hover {
     background-color: #FF4500;
 }
+.break-words {
+    word-break: break-all;
+}

--- a/golynx/static/js/scripts.js
+++ b/golynx/static/js/scripts.js
@@ -18,6 +18,7 @@ document.addEventListener('DOMContentLoaded', function () {
                     redirectionLink.textContent = golink.redirection;
                     redirectionLink.href = golink.redirection;
                     redirectionLink.target = '_blank';
+                    redirectionCell.classList.add('break-words');
                     redirectionCell.appendChild(redirectionLink);
                     row.appendChild(redirectionCell);
 


### PR DESCRIPTION
**Before**
<img width="754" alt="image" src="https://github.com/user-attachments/assets/11854c35-f037-4cac-8d6d-aa0c8180eaec">

**After**
<img width="1508" alt="image" src="https://github.com/user-attachments/assets/c9de624e-b5d3-476f-9154-f2998876ce08">
